### PR TITLE
Adds github template for tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,29 @@
+---
+name: Task
+about: A specific task to assign and implement
+title: "[DECX]: Concise Title"
+labels: ["task"]
+---
+
+## Description
+_A top level description of why this is needed, what it will do and how it fits into this project._
+
+## Relies On
+_Any other issues that must be built before this is started._
+- [ ] Ticket #
+
+## Acceptance Criteria
+
+## Tasks
+_Specific steps to build this out. A top-level description of the algoritm is a good start._
+
+## Dependencies
+_Any new dependencies added due to this being built and instructions on how to include or use them._
+
+## Example Input & Expected Behavior
+_Basic and edge case scenarios described to add to the test suite._
+
+## Definition of Done
+_A checklist of all the things that must be present for this task to be considered for merge._
+- [ ] Reviewed and approved by at least 2 reviewers
+- [ ] Tests written and cumulative coverage of at least 90%


### PR DESCRIPTION
This is a basic template for creating tasks. When creating a new issue ([From the Issues tab](https://github.com/decx-press/decx-press/issues) > "New Issue") this will add a new "Task" selection to the popup, making writing tasks and keeping them consistent much simpler.