### PR TITLE
Fixing security vulnerabilities in transitive dependencies 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -579,28 +579,6 @@
                 "ws": "7.4.6"
             }
         },
-        "node_modules/@ethersproject/providers/node_modules/ws": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-            "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.3.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@ethersproject/random": {
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
@@ -3296,9 +3274,9 @@
             }
         },
         "node_modules/elliptic": {
-            "version": "6.5.4",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+            "version": "6.6.1",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+            "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4639,28 +4617,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 4.0.0"
-            }
-        },
-        "node_modules/hardhat/node_modules/ws": {
-            "version": "7.5.10",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.3.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/has-flag": {
@@ -6933,29 +6889,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/secp256k1/node_modules/bn.js": {
-            "version": "4.12.1",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-            "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/secp256k1/node_modules/elliptic": {
-            "version": "6.6.1",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-            "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bn.js": "^4.11.9",
-                "brorand": "^1.1.0",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.1",
-                "inherits": "^2.0.4",
-                "minimalistic-assert": "^1.0.1",
-                "minimalistic-crypto-utils": "^1.0.1"
-            }
-        },
         "node_modules/secp256k1/node_modules/node-addon-api": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
@@ -8491,12 +8424,11 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,35 +96,6 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
-        "node_modules/@ethereumjs/util/node_modules/@scure/bip32": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
-            "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@noble/curves": "~1.4.0",
-                "@noble/hashes": "~1.4.0",
-                "@scure/base": "~1.1.6"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/@ethereumjs/util/node_modules/@scure/bip39": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
-            "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@noble/hashes": "~1.4.0",
-                "@scure/base": "~1.1.6"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
         "node_modules/@ethereumjs/util/node_modules/ethereum-cryptography": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
@@ -956,6 +927,39 @@
                 "node": ">=12.0.0"
             }
         },
+        "node_modules/@metamask/eth-sig-util/node_modules/@types/bn.js": {
+            "version": "4.11.6",
+            "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+            "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@metamask/eth-sig-util/node_modules/bn.js": {
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+            "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@metamask/eth-sig-util/node_modules/ethereumjs-util": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+            "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "@types/bn.js": "^4.11.3",
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "0.1.6",
+                "rlp": "^2.2.3"
+            }
+        },
         "node_modules/@noble/curves": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
@@ -970,7 +974,7 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
-        "node_modules/@noble/curves/node_modules/@noble/hashes": {
+        "node_modules/@noble/hashes": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
             "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
@@ -983,19 +987,6 @@
             "funding": {
                 "url": "https://paulmillr.com/funding/"
             }
-        },
-        "node_modules/@noble/hashes": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
-            "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://paulmillr.com/funding/"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/@noble/secp256k1": {
             "version": "1.7.1",
@@ -1049,28 +1040,28 @@
             }
         },
         "node_modules/@nomicfoundation/edr": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.7.0.tgz",
-            "integrity": "sha512-+Zyu7TE47TGNcPhOfWLPA/zISs32WDMXrhSWdWYyPHDVn/Uux5TVuOeScKb0BR/R8EJ+leR8COUF/EGxvDOVKg==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.8.0.tgz",
+            "integrity": "sha512-dwWRrghSVBQDpt0wP+6RXD8BMz2i/9TI34TcmZqeEAZuCLei3U9KZRgGTKVAM1rMRvrpf5ROfPqrWNetKVUTag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@nomicfoundation/edr-darwin-arm64": "0.7.0",
-                "@nomicfoundation/edr-darwin-x64": "0.7.0",
-                "@nomicfoundation/edr-linux-arm64-gnu": "0.7.0",
-                "@nomicfoundation/edr-linux-arm64-musl": "0.7.0",
-                "@nomicfoundation/edr-linux-x64-gnu": "0.7.0",
-                "@nomicfoundation/edr-linux-x64-musl": "0.7.0",
-                "@nomicfoundation/edr-win32-x64-msvc": "0.7.0"
+                "@nomicfoundation/edr-darwin-arm64": "0.8.0",
+                "@nomicfoundation/edr-darwin-x64": "0.8.0",
+                "@nomicfoundation/edr-linux-arm64-gnu": "0.8.0",
+                "@nomicfoundation/edr-linux-arm64-musl": "0.8.0",
+                "@nomicfoundation/edr-linux-x64-gnu": "0.8.0",
+                "@nomicfoundation/edr-linux-x64-musl": "0.8.0",
+                "@nomicfoundation/edr-win32-x64-msvc": "0.8.0"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@nomicfoundation/edr-darwin-arm64": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.7.0.tgz",
-            "integrity": "sha512-vAH20oh4GaSB/iQFTRcoO8jLc0CLd9XuLY9I7vtcqZWAiM4U1J4Y8cu67PWmtxbvUQOqXR7S6FtAr8/AlWm14g==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.8.0.tgz",
+            "integrity": "sha512-sKTmOu/P5YYhxT0ThN2Pe3hmCE/5Ag6K/eYoiavjLWbR7HEb5ZwPu2rC3DpuUk1H+UKJqt7o4/xIgJxqw9wu6A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1078,9 +1069,9 @@
             }
         },
         "node_modules/@nomicfoundation/edr-darwin-x64": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.7.0.tgz",
-            "integrity": "sha512-WHDdIrPvLlgXQr2eKypBM5xOZAwdxhDAEQIvEMQL8tEEm2qYW2bliUlssBPrs8E3bdivFbe1HizImslMAfU3+g==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.8.0.tgz",
+            "integrity": "sha512-8ymEtWw1xf1Id1cc42XIeE+9wyo3Dpn9OD/X8GiaMz9R70Ebmj2g+FrbETu8o6UM+aL28sBZQCiCzjlft2yWAg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1088,9 +1079,9 @@
             }
         },
         "node_modules/@nomicfoundation/edr-linux-arm64-gnu": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.7.0.tgz",
-            "integrity": "sha512-WXpJB54ukz1no7gxCPXVEw9pgl/9UZ/WO3l1ctyv/T7vOygjqA4SUd6kppTs6MNXAuTiisPtvJ/fmvHiMBLrsw==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.8.0.tgz",
+            "integrity": "sha512-h/wWzS2EyQuycz+x/SjMRbyA+QMCCVmotRsgM1WycPARvVZWIVfwRRsKoXKdCftsb3S8NTprqBdJlOmsFyETFA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1098,9 +1089,9 @@
             }
         },
         "node_modules/@nomicfoundation/edr-linux-arm64-musl": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.7.0.tgz",
-            "integrity": "sha512-1iZYOcEgc+zJI7JQrlAFziuy9sBz1WgnIx3HIIu0J7lBRZ/AXeHHgATb+4InqxtEx9O3W8A0s7f11SyFqJL4Aw==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.8.0.tgz",
+            "integrity": "sha512-gnWxDgdkka0O9GpPX/gZT3REeKYV28Guyg13+Vj/bbLpmK1HmGh6Kx+fMhWv+Ht/wEmGDBGMCW1wdyT/CftJaQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1108,9 +1099,9 @@
             }
         },
         "node_modules/@nomicfoundation/edr-linux-x64-gnu": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.7.0.tgz",
-            "integrity": "sha512-wSjC94WcR5MM8sg9w3OsAmT6+bbmChJw6uJKoXR3qscps/jdhjzJWzfgT0XGRq3XMUfimyafW2RWOyfX3ouhrQ==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.8.0.tgz",
+            "integrity": "sha512-DTMiAkgAx+nyxcxKyxFZk1HPakXXUCgrmei7r5G7kngiggiGp/AUuBBWFHi8xvl2y04GYhro5Wp+KprnLVoAPA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1118,9 +1109,9 @@
             }
         },
         "node_modules/@nomicfoundation/edr-linux-x64-musl": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.7.0.tgz",
-            "integrity": "sha512-Us22+AZ7wkG1mZwxqE4S4ZcuwkEA5VrUiBOJSvKHGOgy6vFvB/Euh5Lkp4GovwjrtiXuvyGO2UmtkzymZKDxZw==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.8.0.tgz",
+            "integrity": "sha512-iTITWe0Zj8cNqS0xTblmxPbHVWwEtMiDC+Yxwr64d7QBn/1W0ilFQ16J8gB6RVVFU3GpfNyoeg3tUoMpSnrm6Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1128,9 +1119,9 @@
             }
         },
         "node_modules/@nomicfoundation/edr-win32-x64-msvc": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.7.0.tgz",
-            "integrity": "sha512-HAry0heTsWkzReVtjHwoIq3BgFCvXpVhJ5qPmTnegZGsr/KxqvMmHyDMifzKao4bycU8yrpTSyOiAJt27RWjzQ==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.8.0.tgz",
+            "integrity": "sha512-mNRDyd/C3j7RMcwapifzv2K57sfA5xOw8g2U84ZDvgSrXVXLC99ZPxn9kmolb+dz8VMm9FONTZz9ESS6v8DTnA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1184,30 +1175,6 @@
                 }
             }
         },
-        "node_modules/@nomicfoundation/ethereumjs-tx/node_modules/ethereum-cryptography": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-            "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/pbkdf2": "^3.0.0",
-                "@types/secp256k1": "^4.0.1",
-                "blakejs": "^1.1.0",
-                "browserify-aes": "^1.2.0",
-                "bs58check": "^2.1.2",
-                "create-hash": "^1.2.0",
-                "create-hmac": "^1.1.7",
-                "hash.js": "^1.1.7",
-                "keccak": "^3.0.0",
-                "pbkdf2": "^3.0.17",
-                "randombytes": "^2.1.0",
-                "safe-buffer": "^5.1.2",
-                "scrypt-js": "^3.0.0",
-                "secp256k1": "^4.0.1",
-                "setimmediate": "^1.0.5"
-            }
-        },
         "node_modules/@nomicfoundation/ethereumjs-util": {
             "version": "9.0.4",
             "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-9.0.4.tgz",
@@ -1228,30 +1195,6 @@
                 "c-kzg": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@nomicfoundation/ethereumjs-util/node_modules/ethereum-cryptography": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-            "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/pbkdf2": "^3.0.0",
-                "@types/secp256k1": "^4.0.1",
-                "blakejs": "^1.1.0",
-                "browserify-aes": "^1.2.0",
-                "bs58check": "^2.1.2",
-                "create-hash": "^1.2.0",
-                "create-hmac": "^1.1.7",
-                "hash.js": "^1.1.7",
-                "keccak": "^3.0.0",
-                "pbkdf2": "^3.0.17",
-                "randombytes": "^2.1.0",
-                "safe-buffer": "^5.1.2",
-                "scrypt-js": "^3.0.0",
-                "secp256k1": "^4.0.1",
-                "setimmediate": "^1.0.5"
             }
         },
         "node_modules/@nomicfoundation/hardhat-chai-matchers": {
@@ -1291,15 +1234,15 @@
             }
         },
         "node_modules/@nomicfoundation/hardhat-ignition": {
-            "version": "0.15.9",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition/-/hardhat-ignition-0.15.9.tgz",
-            "integrity": "sha512-lSWqhaDOBt6gsqMadkRLvH6HdoFV1v8/bx7z+12cghaOloVwwn48CPoTH2iXXnkqilPGw8rdH5eVTE6UM+2v6Q==",
+            "version": "0.15.10",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition/-/hardhat-ignition-0.15.10.tgz",
+            "integrity": "sha512-UScXyLLG5rEm+ANchQYCDOsskdXl6ux3oCPgC24PKE/QMJEib5crGZIo8spAyzdK6vOnRW6i4FG+1qvoO0AGWA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@nomicfoundation/ignition-core": "^0.15.9",
-                "@nomicfoundation/ignition-ui": "^0.15.9",
+                "@nomicfoundation/ignition-core": "^0.15.10",
+                "@nomicfoundation/ignition-ui": "^0.15.10",
                 "chalk": "^4.0.0",
                 "debug": "^4.3.2",
                 "fs-extra": "^10.0.0",
@@ -1312,59 +1255,18 @@
             }
         },
         "node_modules/@nomicfoundation/hardhat-ignition-ethers": {
-            "version": "0.15.9",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition-ethers/-/hardhat-ignition-ethers-0.15.9.tgz",
-            "integrity": "sha512-9PwwgLv3z2ec3B26mK0IjiFezHFFBcBcs1qKaRu8SanARE4b7RvrfiLIy8ZXE7HaxgPt32kSsQzehhzAwAIj1Q==",
+            "version": "0.15.10",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition-ethers/-/hardhat-ignition-ethers-0.15.10.tgz",
+            "integrity": "sha512-P90glRiBbR4mnMKP/LePovfUJjYT2YWJjx7118i7yxssUwcaW9wFohb4bFh+236N1tqM4q7aGx9cBvHNgve3zA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "peerDependencies": {
                 "@nomicfoundation/hardhat-ethers": "^3.0.4",
-                "@nomicfoundation/hardhat-ignition": "^0.15.9",
-                "@nomicfoundation/ignition-core": "^0.15.9",
+                "@nomicfoundation/hardhat-ignition": "^0.15.10",
+                "@nomicfoundation/ignition-core": "^0.15.10",
                 "ethers": "^6.7.0",
                 "hardhat": "^2.18.0"
-            }
-        },
-        "node_modules/@nomicfoundation/hardhat-ignition/node_modules/fs-extra": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@nomicfoundation/hardhat-ignition/node_modules/jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/@nomicfoundation/hardhat-ignition/node_modules/universalify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 10.0.0"
             }
         },
         "node_modules/@nomicfoundation/hardhat-network-helpers": {
@@ -1379,49 +1281,6 @@
             },
             "peerDependencies": {
                 "hardhat": "^2.9.5"
-            }
-        },
-        "node_modules/@nomicfoundation/hardhat-network-helpers/node_modules/ethereum-cryptography": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-            "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/pbkdf2": "^3.0.0",
-                "@types/secp256k1": "^4.0.1",
-                "blakejs": "^1.1.0",
-                "browserify-aes": "^1.2.0",
-                "bs58check": "^2.1.2",
-                "create-hash": "^1.2.0",
-                "create-hmac": "^1.1.7",
-                "hash.js": "^1.1.7",
-                "keccak": "^3.0.0",
-                "pbkdf2": "^3.0.17",
-                "randombytes": "^2.1.0",
-                "safe-buffer": "^5.1.2",
-                "scrypt-js": "^3.0.0",
-                "secp256k1": "^4.0.1",
-                "setimmediate": "^1.0.5"
-            }
-        },
-        "node_modules/@nomicfoundation/hardhat-network-helpers/node_modules/ethereumjs-util": {
-            "version": "7.1.5",
-            "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
-            "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
-            "dev": true,
-            "license": "MPL-2.0",
-            "peer": true,
-            "dependencies": {
-                "@types/bn.js": "^5.1.0",
-                "bn.js": "^5.1.2",
-                "create-hash": "^1.1.2",
-                "ethereum-cryptography": "^0.1.3",
-                "rlp": "^2.2.4"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/@nomicfoundation/hardhat-toolbox": {
@@ -1452,9 +1311,9 @@
             }
         },
         "node_modules/@nomicfoundation/hardhat-verify": {
-            "version": "2.0.12",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.12.tgz",
-            "integrity": "sha512-Lg3Nu7DCXASQRVI/YysjuAX2z8jwOCbS0w5tz2HalWGSTZThqA0v9N0v0psHbKNqzPJa8bNOeapIVSziyJTnAg==",
+            "version": "2.0.13",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.13.tgz",
+            "integrity": "sha512-i57GX1sC0kYGyRVnbQrjjyBTpWTKgrvKC+jH8CMKV6gHp959Upb8lKaZ58WRHIU0espkulTxLnacYeUDirwJ2g==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -1474,9 +1333,9 @@
             }
         },
         "node_modules/@nomicfoundation/ignition-core": {
-            "version": "0.15.9",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-core/-/ignition-core-0.15.9.tgz",
-            "integrity": "sha512-X8W+7UP/UQPorpHUnGvA1OdsEr/edGi8tDpNwEqzaLm83FMZVbRWdOsr3vNICHN2XMzNY/xIm18Cx7xGKL2PQw==",
+            "version": "0.15.10",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-core/-/ignition-core-0.15.10.tgz",
+            "integrity": "sha512-AWvCviNlBkPT8EKcg34N+yUdQTYFiC/HdpfFZdw8oMFuAs9SMZE0zQA9gJQSCay41GbuyXt2Kietp5/1/nlBIA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -1531,51 +1390,10 @@
                 "node": ">=16"
             }
         },
-        "node_modules/@nomicfoundation/ignition-core/node_modules/fs-extra": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@nomicfoundation/ignition-core/node_modules/jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/@nomicfoundation/ignition-core/node_modules/universalify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
         "node_modules/@nomicfoundation/ignition-ui": {
-            "version": "0.15.9",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-ui/-/ignition-ui-0.15.9.tgz",
-            "integrity": "sha512-8lzbT7gpJ5PoowPQDQilkwdyqBviUKDMoHp/5rhgnwG1bDslnCS+Lxuo6s9R2akWu9LtEL14dNyqQb6WsURTag==",
+            "version": "0.15.10",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-ui/-/ignition-ui-0.15.10.tgz",
+            "integrity": "sha512-82XQPF+1fvxTimDUPgDVwpTjHjfjFgFs84rERbBiMLQbz6sPtgTlV8HHrlbMx8tT/JKCI/SCU4gxV8xA4CPfcg==",
             "dev": true,
             "peer": true
         },
@@ -1686,38 +1504,71 @@
             }
         },
         "node_modules/@scure/bip32": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.5.tgz",
-            "integrity": "sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
+            "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
             "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://paulmillr.com/funding/"
-                }
-            ],
             "license": "MIT",
             "dependencies": {
-                "@noble/hashes": "~1.2.0",
-                "@noble/secp256k1": "~1.7.0",
-                "@scure/base": "~1.1.0"
+                "@noble/curves": "~1.4.0",
+                "@noble/hashes": "~1.4.0",
+                "@scure/base": "~1.1.6"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@scure/bip32/node_modules/@noble/curves": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+            "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "1.4.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+            "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@scure/bip39": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.1.tgz",
-            "integrity": "sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
+            "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
             "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://paulmillr.com/funding/"
-                }
-            ],
             "license": "MIT",
             "dependencies": {
-                "@noble/hashes": "~1.2.0",
-                "@scure/base": "~1.1.0"
+                "@noble/hashes": "~1.4.0",
+                "@scure/base": "~1.1.6"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+            "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@sentry/core": {
@@ -1737,6 +1588,13 @@
                 "node": ">=6"
             }
         },
+        "node_modules/@sentry/core/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true,
+            "license": "0BSD"
+        },
         "node_modules/@sentry/hub": {
             "version": "5.30.0",
             "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
@@ -1752,6 +1610,13 @@
                 "node": ">=6"
             }
         },
+        "node_modules/@sentry/hub/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true,
+            "license": "0BSD"
+        },
         "node_modules/@sentry/minimal": {
             "version": "5.30.0",
             "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
@@ -1766,6 +1631,13 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/@sentry/minimal/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/@sentry/node": {
             "version": "5.30.0",
@@ -1788,6 +1660,13 @@
                 "node": ">=6"
             }
         },
+        "node_modules/@sentry/node/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true,
+            "license": "0BSD"
+        },
         "node_modules/@sentry/tracing": {
             "version": "5.30.0",
             "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.30.0.tgz",
@@ -1804,6 +1683,13 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/@sentry/tracing/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/@sentry/types": {
             "version": "5.30.0",
@@ -1829,12 +1715,22 @@
                 "node": ">=6"
             }
         },
-        "node_modules/@solidity-parser/parser": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.19.0.tgz",
-            "integrity": "sha512-RV16k/qIxW/wWc+mLzV3ARyKUaMUTBy9tOLMzFhtNSKYeTAanQ3a5MudJKf/8arIFnA2L27SNjarQKmFg0w/jA==",
+        "node_modules/@sentry/utils/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "dev": true,
-            "license": "MIT"
+            "license": "0BSD"
+        },
+        "node_modules/@solidity-parser/parser": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.5.tgz",
+            "integrity": "sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "antlr4ts": "^0.5.0-alpha.4"
+            }
         },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.11",
@@ -1917,31 +1813,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/@typechain/hardhat/node_modules/jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/@typechain/hardhat/node_modules/universalify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 10.0.0"
             }
         },
         "node_modules/@types/bn.js": {
@@ -2027,9 +1898,9 @@
             "peer": true
         },
         "node_modules/@types/node": {
-            "version": "22.10.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-            "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+            "version": "22.13.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
+            "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2261,19 +2132,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/anymatch/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/arg": {
@@ -2573,6 +2431,37 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+            "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "get-intrinsic": "^1.2.6"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/camelcase": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -2683,9 +2572,9 @@
             }
         },
         "node_modules/chokidar": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.2.tgz",
-            "integrity": "sha512-/b57FK+bblSU+dfewfFe0rT1YjVDfOmeLQwCAuC+vwvgLkXboATqqmy+Ipux6JrF6L5joe5CBnFOw+gLWH6yKg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2852,55 +2741,12 @@
                 "url": "https://github.com/chalk/ansi-regex?sponsor=1"
             }
         },
-        "node_modules/cli-truncate/node_modules/ansi-styles": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "node_modules/cli-truncate/node_modules/emoji-regex": {
             "version": "10.4.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
             "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-            "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cli-truncate/node_modules/slice-ansi": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-            "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^6.0.0",
-                "is-fullwidth-code-point": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-            }
         },
         "node_modules/cli-truncate/node_modules/string-width": {
             "version": "7.2.0",
@@ -3147,13 +2993,13 @@
             }
         },
         "node_modules/commander": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+            "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 12"
+                "node": ">=18"
             }
         },
         "node_modules/concat-map": {
@@ -3223,9 +3069,9 @@
             }
         },
         "node_modules/core-util-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -3295,22 +3141,6 @@
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
                 "which": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/cross-spawn/node_modules/which": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "node-which": "bin/node-which"
             },
             "engines": {
                 "node": ">= 8"
@@ -3450,6 +3280,21 @@
                 "node": ">=8"
             }
         },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/elliptic": {
             "version": "6.5.4",
             "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
@@ -3517,6 +3362,55 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/escalade": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3561,19 +3455,6 @@
             },
             "optionalDependencies": {
                 "source-map": "~0.2.0"
-            }
-        },
-        "node_modules/escodegen/node_modules/source-map": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-            "integrity": "sha512-CBdZ2oa/BHhS4xj5DlhjWNHcan57/5YuvfdLf17iVmIpd9KRm+DFLmC6nBNj+6Ua7Kt3TmOjDpQT1aTYOQtoUA==",
-            "dev": true,
-            "optional": true,
-            "dependencies": {
-                "amdefine": ">=0.0.4"
-            },
-            "engines": {
-                "node": ">=0.8.0"
             }
         },
         "node_modules/esprima": {
@@ -3639,14 +3520,65 @@
                 }
             }
         },
-        "node_modules/eth-gas-reporter/node_modules/@solidity-parser/parser": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.5.tgz",
-            "integrity": "sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==",
+        "node_modules/eth-gas-reporter/node_modules/@noble/hashes": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+            "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/eth-gas-reporter/node_modules/@scure/bip32": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.5.tgz",
+            "integrity": "sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "~1.2.0",
+                "@noble/secp256k1": "~1.7.0",
+                "@scure/base": "~1.1.0"
+            }
+        },
+        "node_modules/eth-gas-reporter/node_modules/@scure/bip39": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.1.tgz",
+            "integrity": "sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "~1.2.0",
+                "@scure/base": "~1.1.0"
+            }
+        },
+        "node_modules/eth-gas-reporter/node_modules/ethereum-cryptography": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
+            "integrity": "sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "antlr4ts": "^0.5.0-alpha.4"
+                "@noble/hashes": "1.2.0",
+                "@noble/secp256k1": "1.7.1",
+                "@scure/bip32": "1.1.5",
+                "@scure/bip39": "1.1.1"
             }
         },
         "node_modules/eth-gas-reporter/node_modules/ethers": {
@@ -3709,9 +3641,9 @@
             }
         },
         "node_modules/ethereum-bloom-filters/node_modules/@noble/hashes": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
-            "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+            "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3722,71 +3654,6 @@
             }
         },
         "node_modules/ethereum-cryptography": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
-            "integrity": "sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@noble/hashes": "1.2.0",
-                "@noble/secp256k1": "1.7.1",
-                "@scure/bip32": "1.1.5",
-                "@scure/bip39": "1.1.1"
-            }
-        },
-        "node_modules/ethereumjs-abi": {
-            "version": "0.6.8",
-            "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
-            "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
-            "deprecated": "This library has been deprecated and usage is discouraged.",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bn.js": "^4.11.8",
-                "ethereumjs-util": "^6.0.0"
-            }
-        },
-        "node_modules/ethereumjs-abi/node_modules/bn.js": {
-            "version": "4.12.1",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-            "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/ethereumjs-util": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-            "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-            "dev": true,
-            "license": "MPL-2.0",
-            "dependencies": {
-                "@types/bn.js": "^4.11.3",
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
-                "ethjs-util": "0.1.6",
-                "rlp": "^2.2.3"
-            }
-        },
-        "node_modules/ethereumjs-util/node_modules/@types/bn.js": {
-            "version": "4.11.6",
-            "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-            "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/ethereumjs-util/node_modules/bn.js": {
-            "version": "4.12.1",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-            "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/ethereumjs-util/node_modules/ethereum-cryptography": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
             "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
@@ -3810,10 +3677,73 @@
                 "setimmediate": "^1.0.5"
             }
         },
+        "node_modules/ethereumjs-abi": {
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
+            "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
+            "deprecated": "This library has been deprecated and usage is discouraged.",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.11.8",
+                "ethereumjs-util": "^6.0.0"
+            }
+        },
+        "node_modules/ethereumjs-abi/node_modules/@types/bn.js": {
+            "version": "4.11.6",
+            "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+            "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/ethereumjs-abi/node_modules/bn.js": {
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+            "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ethereumjs-abi/node_modules/ethereumjs-util": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+            "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "@types/bn.js": "^4.11.3",
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "0.1.6",
+                "rlp": "^2.2.3"
+            }
+        },
+        "node_modules/ethereumjs-util": {
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
+            "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "peer": true,
+            "dependencies": {
+                "@types/bn.js": "^5.1.0",
+                "bn.js": "^5.1.2",
+                "create-hash": "^1.1.2",
+                "ethereum-cryptography": "^0.1.3",
+                "rlp": "^2.2.4"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/ethers": {
-            "version": "6.13.4",
-            "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.4.tgz",
-            "integrity": "sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==",
+            "version": "6.13.5",
+            "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.5.tgz",
+            "integrity": "sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==",
             "dev": true,
             "funding": [
                 {
@@ -3840,20 +3770,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/ethers/node_modules/@noble/hashes": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-            "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 16"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
         "node_modules/ethers/node_modules/@types/node": {
             "version": "22.7.5",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
@@ -3865,14 +3781,6 @@
                 "undici-types": "~6.19.2"
             }
         },
-        "node_modules/ethers/node_modules/tslib": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-            "dev": true,
-            "license": "0BSD",
-            "peer": true
-        },
         "node_modules/ethers/node_modules/undici-types": {
             "version": "6.19.8",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
@@ -3880,29 +3788,6 @@
             "dev": true,
             "license": "MIT",
             "peer": true
-        },
-        "node_modules/ethers/node_modules/ws": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/ethjs-unit": {
             "version": "0.1.6",
@@ -3992,9 +3877,9 @@
             "peer": true
         },
         "node_modules/fast-glob": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-            "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4002,7 +3887,7 @@
                 "@nodelib/fs.walk": "^1.2.3",
                 "glob-parent": "^5.1.2",
                 "merge2": "^1.3.0",
-                "micromatch": "^4.0.4"
+                "micromatch": "^4.0.8"
             },
             "engines": {
                 "node": ">=8.6.0"
@@ -4016,36 +3901,31 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
-            "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+            "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
             "license": "BSD-3-Clause",
             "peer": true
         },
         "node_modules/fastq": {
-            "version": "1.17.1",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-            "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
+            "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
-            }
-        },
-        "node_modules/fdir": {
-            "version": "6.4.2",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
-            "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
             }
         },
         "node_modules/fill-range": {
@@ -4124,14 +4004,15 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-            "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+            "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
                 "mime-types": "^2.1.12"
             },
             "engines": {
@@ -4146,18 +4027,19 @@
             "license": "MIT"
         },
         "node_modules/fs-extra": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=6 <7 || >=8"
+                "node": ">=12"
             }
         },
         "node_modules/fs-readdir-recursive": {
@@ -4187,6 +4069,16 @@
             ],
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/get-caller-file": {
@@ -4223,6 +4115,31 @@
                 "node": "*"
             }
         },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/get-port": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
@@ -4231,6 +4148,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/get-stream": {
@@ -4400,6 +4331,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/global-prefix/node_modules/which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "which": "bin/which"
+            }
+        },
         "node_modules/globby": {
             "version": "10.0.2",
             "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
@@ -4466,6 +4410,19 @@
                 "node": "*"
             }
         },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4495,16 +4452,26 @@
                 "uglify-js": "^3.1.4"
             }
         },
+        "node_modules/handlebars/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/hardhat": {
-            "version": "2.22.18",
-            "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.18.tgz",
-            "integrity": "sha512-2+kUz39gvMo56s75cfLBhiFedkQf+gXdrwCcz4R/5wW0oBdwiyfj2q9BIkMoaA0WIGYYMU2I1Cc4ucTunhfjzw==",
+            "version": "2.22.19",
+            "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.19.tgz",
+            "integrity": "sha512-jptJR5o6MCgNbhd7eKa3mrteR+Ggq1exmE5RUL5ydQEVKcZm0sss5laa86yZ0ixIavIvF4zzS7TdGDuyopj0sQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@ethersproject/abi": "^5.1.2",
                 "@metamask/eth-sig-util": "^4.0.0",
-                "@nomicfoundation/edr": "^0.7.0",
+                "@nomicfoundation/edr": "^0.8.0",
                 "@nomicfoundation/ethereumjs-common": "4.0.4",
                 "@nomicfoundation/ethereumjs-tx": "5.0.4",
                 "@nomicfoundation/ethereumjs-util": "9.0.4",
@@ -4578,6 +4545,124 @@
                 "hardhat": "^2.0.2"
             }
         },
+        "node_modules/hardhat/node_modules/@noble/hashes": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+            "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/hardhat/node_modules/@scure/bip32": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.5.tgz",
+            "integrity": "sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "~1.2.0",
+                "@noble/secp256k1": "~1.7.0",
+                "@scure/base": "~1.1.0"
+            }
+        },
+        "node_modules/hardhat/node_modules/@scure/bip39": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.1.tgz",
+            "integrity": "sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "~1.2.0",
+                "@scure/base": "~1.1.0"
+            }
+        },
+        "node_modules/hardhat/node_modules/ethereum-cryptography": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
+            "integrity": "sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "1.2.0",
+                "@noble/secp256k1": "1.7.1",
+                "@scure/bip32": "1.1.5",
+                "@scure/bip39": "1.1.1"
+            }
+        },
+        "node_modules/hardhat/node_modules/fs-extra": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
+            }
+        },
+        "node_modules/hardhat/node_modules/jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+            "dev": true,
+            "license": "MIT",
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/hardhat/node_modules/universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/hardhat/node_modules/ws": {
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4586,6 +4671,35 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/hash-base": {
@@ -4612,6 +4726,19 @@
             "dependencies": {
                 "inherits": "^2.0.3",
                 "minimalistic-assert": "^1.0.1"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/he": {
@@ -4855,13 +4982,16 @@
             }
         },
         "node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+            "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=8"
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-glob": {
@@ -5009,19 +5139,23 @@
             }
         },
         "node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
         },
         "node_modules/jsonschema": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-            "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
+            "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5131,16 +5265,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/lint-staged/node_modules/commander": {
-            "version": "13.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-            "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/listr2": {
@@ -5289,6 +5413,7 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
             "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+            "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
             "dev": true,
             "license": "MIT",
             "peer": true
@@ -5505,6 +5630,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/md5.js": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -5562,19 +5697,6 @@
             },
             "engines": {
                 "node": ">=8.6"
-            }
-        },
-        "node_modules/micromatch/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/mime-db": {
@@ -5745,19 +5867,6 @@
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
-            }
-        },
-        "node_modules/mocha/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/mocha/node_modules/readdirp": {
@@ -5948,10 +6057,23 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/object-inspect": {
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/obliterator": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
-            "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
+            "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
             "dev": true,
             "license": "MIT"
         },
@@ -6154,13 +6276,13 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=12"
+                "node": ">=8.6"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
@@ -6199,9 +6321,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-            "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.2.tgz",
+            "integrity": "sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -6230,6 +6352,13 @@
             "peerDependencies": {
                 "prettier": ">=2.3.0"
             }
+        },
+        "node_modules/prettier-plugin-solidity/node_modules/@solidity-parser/parser": {
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.19.0.tgz",
+            "integrity": "sha512-RV16k/qIxW/wWc+mLzV3ARyKUaMUTBy9tOLMzFhtNSKYeTAanQ3a5MudJKf/8arIFnA2L27SNjarQKmFg0w/jA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/prettier-plugin-solidity/node_modules/semver": {
             "version": "7.7.1",
@@ -6284,13 +6413,19 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.5.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-            "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "dependencies": {
+                "side-channel": "^1.1.0"
+            },
             "engines": {
                 "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/queue-microtask": {
@@ -6356,13 +6491,13 @@
             }
         },
         "node_modules/readdirp": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
-            "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 14.16.0"
+                "node": ">= 14.18.0"
             },
             "funding": {
                 "type": "individual",
@@ -6533,9 +6668,9 @@
             }
         },
         "node_modules/reusify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6762,6 +6897,19 @@
                 "node": ">=0.8.0"
             }
         },
+        "node_modules/sc-istanbul/node_modules/which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "which": "bin/which"
+            }
+        },
         "node_modules/scrypt-js": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
@@ -6964,6 +7112,82 @@
                 "node": "*"
             }
         },
+        "node_modules/side-channel": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3",
+                "side-channel-list": "^1.0.0",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/signal-exit": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6996,22 +7220,33 @@
             }
         },
         "node_modules/slice-ansi": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+            "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "astral-regex": "^2.0.0",
-                "is-fullwidth-code-point": "^3.0.0"
+                "ansi-styles": "^6.0.0",
+                "is-fullwidth-code-point": "^4.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
+        "node_modules/slice-ansi/node_modules/ansi-styles": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/solc": {
@@ -7034,6 +7269,16 @@
             },
             "engines": {
                 "node": ">=10.0.0"
+            }
+        },
+        "node_modules/solc/node_modules/commander": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/solc/node_modules/semver": {
@@ -7079,6 +7324,13 @@
             "peerDependencies": {
                 "hardhat": "^2.11.0"
             }
+        },
+        "node_modules/solidity-coverage/node_modules/@solidity-parser/parser": {
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.19.0.tgz",
+            "integrity": "sha512-RV16k/qIxW/wWc+mLzV3ARyKUaMUTBy9tOLMzFhtNSKYeTAanQ3a5MudJKf/8arIFnA2L27SNjarQKmFg0w/jA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/solidity-coverage/node_modules/ansi-styles": {
             "version": "3.2.1",
@@ -7160,10 +7412,20 @@
                 "node": ">=4"
             }
         },
+        "node_modules/solidity-coverage/node_modules/jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+            "dev": true,
+            "license": "MIT",
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
         "node_modules/solidity-coverage/node_modules/semver": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -7186,14 +7448,27 @@
                 "node": ">=4"
             }
         },
-        "node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+        "node_modules/solidity-coverage/node_modules/universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
             "dev": true,
-            "license": "BSD-3-Clause",
+            "license": "MIT",
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+            "integrity": "sha512-CBdZ2oa/BHhS4xj5DlhjWNHcan57/5YuvfdLf17iVmIpd9KRm+DFLmC6nBNj+6Ua7Kt3TmOjDpQT1aTYOQtoUA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "amdefine": ">=0.0.4"
+            },
+            "engines": {
+                "node": ">=0.8.0"
             }
         },
         "node_modules/source-map-support": {
@@ -7205,6 +7480,16 @@
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/source-map-support/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/split2": {
@@ -7226,9 +7511,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/stacktrace-parser": {
-            "version": "0.1.10",
-            "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz",
-            "integrity": "sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==",
+            "version": "0.1.11",
+            "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
+            "integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7297,6 +7582,16 @@
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.1"
             },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -7449,6 +7744,36 @@
                 "node": ">=8"
             }
         },
+        "node_modules/table/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/table/node_modules/slice-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
         "node_modules/then-request": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
@@ -7480,15 +7805,16 @@
             "license": "MIT"
         },
         "node_modules/then-request/node_modules/form-data": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.2.tgz",
-            "integrity": "sha512-GgwY0PS7DbXqajuGf4OYlsrIu3zgxD6Vvql43IBhm6MahqA5SK/7mwhtNj2AdH2z35YR34ujJ7BN+3fFC3jP5Q==",
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
+            "integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "mime-types": "^2.1.35",
                 "safe-buffer": "^5.2.1"
             },
             "engines": {
@@ -7507,17 +7833,48 @@
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
-            "integrity": "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==",
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
+            "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fdir": "^6.4.2",
+                "fdir": "^6.4.3",
                 "picomatch": "^4.0.2"
             },
             "engines": {
                 "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
+            "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/tmp": {
@@ -7641,11 +7998,12 @@
             }
         },
         "node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
             "dev": true,
-            "license": "0BSD"
+            "license": "0BSD",
+            "peer": true
         },
         "node_modules/tsort": {
             "version": "0.0.1",
@@ -7743,6 +8101,22 @@
                 "concat-map": "0.0.1"
             }
         },
+        "node_modules/typechain/node_modules/fs-extra": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
+            }
+        },
         "node_modules/typechain/node_modules/glob": {
             "version": "7.1.7",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
@@ -7764,6 +8138,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/typechain/node_modules/jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
             }
         },
         "node_modules/typechain/node_modules/minimatch": {
@@ -7811,6 +8196,17 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
+        "node_modules/typechain/node_modules/universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
         "node_modules/typedarray": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -7819,9 +8215,9 @@
             "license": "MIT"
         },
         "node_modules/typescript": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-            "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+            "version": "5.7.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+            "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
             "dev": true,
             "license": "Apache-2.0",
             "peer": true,
@@ -7879,13 +8275,14 @@
             "license": "MIT"
         },
         "node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
-                "node": ">= 4.0.0"
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/unpipe": {
@@ -7976,35 +8373,6 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
-        "node_modules/web3-utils/node_modules/@scure/bip32": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
-            "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@noble/curves": "~1.4.0",
-                "@noble/hashes": "~1.4.0",
-                "@scure/base": "~1.1.6"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/web3-utils/node_modules/@scure/bip39": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
-            "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@noble/hashes": "~1.4.0",
-                "@scure/base": "~1.1.6"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
         "node_modules/web3-utils/node_modules/ethereum-cryptography": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
@@ -8019,16 +8387,19 @@
             }
         },
         "node_modules/which": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
             },
             "bin": {
-                "which": "bin/which"
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/widest-line": {
@@ -8120,17 +8491,18 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "7.5.10",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
-                "node": ">=8.3.0"
+                "node": ">=10.0.0"
             },
             "peerDependencies": {
                 "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
+                "utf-8-validate": ">=5.0.2"
             },
             "peerDependenciesMeta": {
                 "bufferutil": {

--- a/package.json
+++ b/package.json
@@ -53,5 +53,9 @@
         "prettier": "^3.4.2",
         "prettier-plugin-solidity": "^1.4.2",
         "solidity-coverage": "^0.8.14"
+    },
+    "overrides": {
+        "elliptic": ">=6.6.1",
+        "ws": ">=7.5.10"
     }
 }


### PR DESCRIPTION
## Description

- **Related Issue:** #32 

### Minor/patch updates before getting into the security issues 

Outdated packages: 

```sh
Package               Current   Wanted   Latest  Location                           Depended by
hardhat               2.22.18  2.22.19  2.22.19  node_modules/hardhat               decx-press
hardhat-gas-reporter   1.0.10   1.0.10    2.2.2  node_modules/hardhat-gas-reporter  decx-press
prettier                3.4.2    3.5.2    3.5.2  node_modules/prettier              decx-press
```

The patch update for hardhat and the minor update for prettier leave only hardhat-gas-reporter outdated. 

```sh
Package               Current  Wanted  Latest  Location                           Depended by
hardhat-gas-reporter   1.0.10  1.0.10   2.2.2  node_modules/hardhat-gas-reporter  decx-press
```

@nomicfoundation/hardhat-toolbox, which doesn't currently have an update available, depends on the current version of hardhat-gas-reporter, and 2.x.x is a breaking change. hardhat-gas-reporter is one of the packages that depends on one of the transitive dependencies with security vulnerabilities, but it is not the only source of the issue. 

### Addressing security vulnerabilities 

The main security issues involve elliptic (critical) and ws (high). Elliptic needs to be upgraded to at least 6.6.1, and ws needs to be upgraded to at least 7.5.10. There are several dependencies that depend on the vulnerable versions. Here is where the packages are in the dependency tree: 

#### elliptic 

```
decx-press@1.0.0 
├─┬ hardhat-gas-reporter@1.0.10
│ └─┬ eth-gas-reporter@0.2.27
│   └─┬ ethers@5.7.2
│     └─┬ @ethersproject/signing-key@5.7.0
│       └── elliptic@6.5.4 deduped
└─┬ hardhat@2.22.19
  ├─┬ @metamask/eth-sig-util@4.0.1
  │ └─┬ ethereumjs-util@6.2.1
  │   └── elliptic@6.5.4
  ├─┬ @nomicfoundation/ethereumjs-tx@5.0.4
  │ └─┬ ethereum-cryptography@0.1.3
  │   └─┬ secp256k1@4.0.4
  │     └── elliptic@6.6.1
  └─┬ ethereumjs-abi@0.6.8
    └─┬ ethereumjs-util@6.2.1
      └── elliptic@6.5.4 deduped
```

#### ws

```
decx-press@1.0.0 
├─┬ @nomicfoundation/hardhat-toolbox@5.0.0
│ └─┬ ethers@6.13.5
│   └── ws@8.17.1
├─┬ hardhat-gas-reporter@1.0.10
│ └─┬ eth-gas-reporter@0.2.27
│   └─┬ ethers@5.7.2
│     └─┬ @ethersproject/providers@5.7.2
│       └── ws@7.4.6
└─┬ hardhat@2.22.19
  └── ws@7.5.10
```

Unfortunately, updates are not available for the parent dependencies of elliptic and ws. To solve this and fix the security issues, this PR overrides the vulnerable versions of these transitive dependencies in `package.json`. 

```
    "overrides": {
        "elliptic": ">=6.6.1",
        "ws": ">=7.5.10"
    }
```

After reinstalling `node_modules`, all tests still pass and local deployment still works. Some low vulnerabilities remain, but this PR fixes the high and critical vulnerabilities. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): Security vulnerability fix (non-breaking) 

## How Has This Been Tested?

With the new versions of all dependencies installed, all tests pass and local deployment is successful. 

- **`npm run test`:** 34 passing
- **`npm run test:fees`:** 34 passing
- **`npm run test:ci`:** 29 passing 5 pending (this is the same on main) 

- **Local deployment** (with `npm run node` in one terminal tab and `npm run deploy --module=DecxDAG --network=localhost` in another): [ DecxDAGModule ] successfully deployed 🚀 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules