### PR TITLE
Gas optimizations [comparing to 34-offchain-encryption]

### DIFF
--- a/contracts/decxDAG_units/DecxRegistry.sol
+++ b/contracts/decxDAG_units/DecxRegistry.sol
@@ -71,7 +71,7 @@ contract DecxRegistry is IDecxRegistry {
         }
 
         // Encode the hashes and hash them as a single hash
-        bytes32 hashesHash = keccak256(abi.encode(hash1, hash2));
+        bytes32 hashesHash = keccak256(abi.encodePacked(hash1, hash2));
 
         // add the composite hash to the hash & lookup mappings
         hashExistsMap[hashesHash] = true;

--- a/contracts/decxDAG_units/UTF8Validator.sol
+++ b/contracts/decxDAG_units/UTF8Validator.sol
@@ -12,16 +12,21 @@ contract UTF8Validator is IUTF8Validator {
         bytes1 firstByte = b[0];
 
         // Determine expected length from first byte
-        if (firstByte >= 0xF0) {
-            if (l != 4) revert UTF8_InvalidCharacter();
-        } else if (firstByte >= 0xE0) {
-            if (l != 3) revert UTF8_InvalidCharacter();
-        } else if (firstByte >= 0xC0) {
-            if (l != 2) revert UTF8_InvalidCharacter();
-        } else if (firstByte >= 0x80) {
+        if (firstByte < 0x80) {
+            // Single-byte (ASCII)
+            if (l != 1) revert UTF8_InvalidCharacter();
+        } else if (firstByte < 0xC0) {
+            // 10xxxxxx as first byte → invalid
             revert UTF8_InvalidLeadingByte();
-        } else if (l != 1) {
-            revert UTF8_InvalidCharacter();
+        } else if (firstByte < 0xE0) {
+            // 110xxxxx
+            if (l != 2) revert UTF8_InvalidCharacter();
+        } else if (firstByte < 0xF0) {
+            // 1110xxxx
+            if (l != 3) revert UTF8_InvalidCharacter();
+        } else {
+            // >= 0xF0 → 11110xxx
+            if (l != 4) revert UTF8_InvalidCharacter();
         }
 
         // Multi-byte path

--- a/contracts/decxDAG_units/UTF8Validator.sol
+++ b/contracts/decxDAG_units/UTF8Validator.sol
@@ -4,37 +4,34 @@ pragma solidity ^0.8.28;
 import "../interfaces/IUTF8Validator.sol";
 
 contract UTF8Validator is IUTF8Validator {
-    function validateCharacter(string memory character) public pure override {
-        bytes memory b = bytes(character);
+    function validateCharacter(string calldata character) external pure override {
+        bytes calldata b = bytes(character);
         uint256 l = b.length;
-
-        // First check: length must be 1-4 bytes
         if (l == 0 || l > 4) revert UTF8_InvalidCharacter();
 
         bytes1 firstByte = b[0];
 
-        // Determine expected length based on first byte
-        uint256 expectedLength;
-        if (firstByte >= 0xF0) expectedLength = 4;      // 11110xxx
-        else if (firstByte >= 0xE0) expectedLength = 3; // 1110xxxx
-        else if (firstByte >= 0xC0) expectedLength = 2; // 110xxxxx
-        else if (firstByte >= 0x80) revert UTF8_InvalidLeadingByte(); // 10xxxxxx is never valid as first byte
-        else expectedLength = 1;                        // 0xxxxxxx
+        // Determine expected length from first byte
+        if (firstByte >= 0xF0) {
+            if (l != 4) revert UTF8_InvalidCharacter();
+        } else if (firstByte >= 0xE0) {
+            if (l != 3) revert UTF8_InvalidCharacter();
+        } else if (firstByte >= 0xC0) {
+            if (l != 2) revert UTF8_InvalidCharacter();
+        } else if (firstByte >= 0x80) {
+            revert UTF8_InvalidLeadingByte();
+        } else if (l != 1) {
+            revert UTF8_InvalidCharacter();
+        }
 
-        // Check if actual length matches expected length
-        if (l != expectedLength) revert UTF8_InvalidCharacter();
-
-        // Now validate based on length
-        if (l >= 2) {
-            // Multi-byte validation...
-            // Validate continuation bytes (must be 10xxxxxx)
-            for (uint i = 1; i < l; i++) {
+        // Multi-byte path
+        if (l > 1) {
+            for (uint256 i = 1; i < l; i++) {
                 bytes1 contByte = b[i];
                 if (contByte < 0x80 || contByte > 0xBF) revert UTF8_InvalidContinuationByte();
             }
         } else {
-            // Single byte validation...
-            // Single byte must be valid ASCII (0x20-0x7F)
+            // Single-byte path
             if (firstByte <= 0x1F || firstByte == 0x7F) {
                 revert UTF8_ControlCharacterNotAllowed();
             }

--- a/contracts/interfaces/IUTF8Validator.sol
+++ b/contracts/interfaces/IUTF8Validator.sol
@@ -14,5 +14,5 @@ interface IUTF8Validator {
     /// @notice Validates a single UTF-8 character
     /// @dev Checks for valid UTF-8 encoding and disallows control characters
     /// @param character The string containing exactly one UTF-8 character
-    function validateCharacter(string memory character) external pure;
+    function validateCharacter(string calldata character) external pure;
 }

--- a/services/dEKService.ts
+++ b/services/dEKService.ts
@@ -1,5 +1,4 @@
-// decx Encryption Key Service (dEKService)
-import { Contract, ethers, EventLog, Log, Result } from "ethers";
+import { Contract, ethers, EventLog, Result } from "ethers";
 import { ECIESService } from "./encryption/ECIESService";
 
 /**

--- a/services/encryption/ECIESService.ts
+++ b/services/encryption/ECIESService.ts
@@ -15,10 +15,6 @@ export class ECIESService {
     private readonly AUTH_TAG_SIZE = 16; // AES-GCM auth tag size
     private readonly MAC_SIZE = 32; // HMAC-SHA256 size
     private readonly HASH_SIZE = 32; // Size of each hash
-    private readonly AES_BLOCK_SIZE = 16; // AES block size for padding
-
-    // Total overhead size (everything except encrypted content)
-    private readonly OVERHEAD_SIZE = this.EPHEMERAL_PUBKEY_SIZE + this.IV_SIZE + this.AUTH_TAG_SIZE + this.MAC_SIZE;
 
     // Maximum sizes for our two types of content
     private readonly MAX_CHAR_SIZE = 4; // Maximum UTF-8 character size


### PR DESCRIPTION
## Description

These changes don't link to a ticket, but they are aimed at improvements and computing efficiency to reduce gas fees.

These changes include:
- incorporating Hashes lookup mapping back to a trie (2d array) versus encoding & hashing prior to lookup
- using calldata/public in function signatures when the passed arguments do not need to be written to memory
- reducing the usage for local variables if they can be inferred from other items in function state
- optimizing if/else statements to short circuit from 1-byte characters to 4-byte characters
- editing reduceHashes array in-place versus creating a new array for each reduction level

One weird note, in `DecxRegistry.addHashesHash()` setting the individual hashes from the input array to variables reduces fees as opposed to using them as indexed items in the passed in `hashes` array, which is why `hash1` and `hash2` are created instead of using `hashes[0]` and `hashes[1]`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other: Unticketed optimization

## How Has This Been Tested?

Comparing the tests **before** the changes:
```sh
┌─────────┬──────────────────────────────────────┬──────────────┬───────────┬───────────┐
│ (index) │              Operation               │  Gas price   │  Gas fee  │  In USD   │
├─────────┼──────────────────────────────────────┼──────────────┼───────────┼───────────┤
│    0    │  'novel hashing of "Hello, world!"'  │ '1594286349' │ '1713408' │ '$5.5861' │
│    1    │ 'hashing attempt of "Hello, world!"' │ '1528486014' │ '268540'  │ '$0.8394' │
│    2    │ 'hashing attempt of "hello, world!"' │ '1463607926' │ '650946'  │ '$1.9483' │
└─────────┴──────────────────────────────────────┴──────────────┴───────────┴───────────┘
```

to **after** the changes:

```sh
    Gas Optimization
┌─────────┬──────────────────────────────────────┬──────────────┬───────────┬───────────┐
│ (index) │              Operation               │  Gas price   │  Gas fee  │  In USD   │
├─────────┼──────────────────────────────────────┼──────────────┼───────────┼───────────┤
│    0    │  'novel hashing of "Hello, world!"'  │ '1594068901' │ '1707010' │ '$5.5626' │
│    1    │ 'hashing attempt of "Hello, world!"' │ '1528260968' │ '260174'  │ '$0.8128' │
│    2    │ 'hashing attempt of "hello, world!"' │ '1463373679' │ '643236'  │ '$1.9243' │
└─────────┴──────────────────────────────────────┴──────────────┴───────────┴───────────┘
```

Take special note of the **Gas fee** column, as the Gas price is tied to the current ETH price, which can vary from second to second. As you can see, these aren't big gains, but offer a notable decrease in fees. When dealing with larger strings or many batches of pressings, this can reduce large amounts of fees.

## How to check
To check it yourself, pull down any branch, but recommended `main` or `34-offchain-encryption` and run `npm run test:fees` and view the output. Then switch to this branch and run `npm run test:fees` again to verify the Gas fees are lower in every instance.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
